### PR TITLE
Spot dead locks:

### DIFF
--- a/lib/lock_manager.js
+++ b/lib/lock_manager.js
@@ -82,14 +82,21 @@ var LockManager = new JS.Class(
                         logger.error("LockManager: " + err);
                     }
                     else {
+                        /* man pgrep: pgrep looks through the currently running processes and lists
+                                      the process IDs which matches the selection criteria to stdout:
+                            $ pgrep node
+                            2535
+                            2537
+                            2538
+                        */
                         exec('pgrep node', function(error, stdout, stderr) {
                             if (error) {
                                 logger.error("LockManager: " + error);
                             }
                             var pids = stdout.split('\n');
-                            if (pids.indexOf(''+data) === -1) {
+                            if (pids.indexOf('' + data) === -1) { /* casting to string because data is apparently an Object */
                                 logger.error("SEVERE: PROCESS WITH PID=" + data + ", OWNER OF LOCK " + lockName +
-                                    " DOES NOT EXIST.");
+                                    ", DOES NOT EXIST.");
                             }
                         });
                     }
@@ -154,6 +161,7 @@ var LockManager = new JS.Class(
                         // We got the lock.  We can fulfill our future!  For great justice!
                         self.lockOwnerCache[lockName] = owner;
                         self.lockFileDescriptorCache[lockName] = fd;
+                        /* store pid of the process that took the lock in the lock file */
                         fs.write(fd, process.pid, null, null, null, function() {
                             future.fulfill(undefined, lockName, owner, elapsedTimeMillis);
                         });


### PR DESCRIPTION
Record the PID of the lock owner, and check if the PID still exists when we fail to obtain the lock.
