### PR TITLE
ENINAWEB-2136 - Delete empty lock file

### DIFF
--- a/lib/lock_manager.js
+++ b/lib/lock_manager.js
@@ -75,37 +75,6 @@ var LockManager = new Class(
             var elapsedTimeMillis = now - firstCallTime;
             if (elapsedTimeMillis > timeout)
             {
-                /* Check if the process owning the lock still exists, to spot dead locks. */
-                fs.readFile(self.__buildLockFileName(lockName), function(err, data) {
-                    if (err) {
-                        logger.error("LockManager: " + err);
-                    }
-                    else {
-                        /* man pgrep: pgrep looks through the currently running processes and lists
-                                      the process IDs which matches the selection criteria to stdout:
-                            $ pgrep node
-                            2535
-                            2537
-                            2538
-                        */
-                        exec('pgrep node', function(error, stdout, stderr) {
-                            if (error) {
-                                logger.error("LockManager: " + error);
-                            }
-                            var pids = stdout.split('\n');
-                            if (pids.indexOf('' + data) === -1) { /* casting to string because data is apparently an Object */
-                                logger.error("SEVERE: PROCESS WITH PID=" + data + ", OWNER OF LOCK " + lockName +
-                                    ", DOES NOT EXIST. DELETING THE LOCK.");
-                                fs.unlink(self.__buildLockFileName(lockName), function(err) {
-                                    if (err) {
-                                        logger.error('Error while deleting lock ' + lockName + ': ' + err);
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
-
                 var lockOwner = self.lockOwnerCache[lockName];
 
                 var message = util.format("Unable to obtain exclusive lock %s for owner %j within the %dms specified " +
@@ -157,6 +126,71 @@ var LockManager = new Class(
                                                 lockFileName,
                                                 owner,
                                                 self.settings.lockRetryTimeMillis));
+                        /* Check if the process owning the lock still exists, to spot dead locks.
+
+                        There are two cases:
+                        1. The file  without PID: Something went wrong after file creation and before writing to PID in the file.
+                        2. The file with PID: Something went wrong after file creation with PID and somehow lock file was not deleted
+
+                        ENINAWEB-2136
+                        Pre: Kquery server is retrying until timeout and then it's deleting inactive lock file.
+                        now: Before first retry, check if the lock file exist and it's having PID then match with active PID , 
+                        if there is no match then delete the file and retry. Also, if the file is empty then delete and retry.
+                        */
+                        
+                       fs.readFile(lockFileName, function (err, data) {
+                        if (err) {
+                            logger.error("LockManager: " + err);
+                        }
+                        else {
+                            // first check for empty file
+                            if (data.byteLength === 0) {
+                                fs.stat(lockFileName, function (statError, statData) {
+                                    if (statError) {
+                                        logger.error("LockManager: Error while fetching the file "+ lockFileName + " details:" + statError)
+                                    }
+                                    else {
+                                        var creationDate = statData.birthtimeMs;
+                                        // The call was just to make sure file was created abefore first call 
+                                        if (firstCallTime > creationDate) {
+                                            logger.error("LockManager: SEVERE: Owner doesn't exist for lock file "+ lockFileName +" , hence deleting the lock file");
+                                            fs.unlink(lockFileName, function (err) {
+                                                if (err) {
+                                                    logger.error("LockManager: Error while deleting lock " + lockName + ": " + err);
+                                                }
+                                            });
+                                        }
+                                    }
+
+                                });
+                            }
+                            else {
+                                /* man pgrep: pgrep looks through the currently running processes and lists
+                                            the process IDs which matches the selection criteria to stdout:
+                                    $ pgrep node
+                                    2535
+                                    2537
+                                    2538
+                                */
+                                exec('pgrep node', function (error, stdout, stderr) {
+                                    if (error) {
+                                        logger.error("LockManager: " + error);
+                                    }
+                                    var pids = stdout.split('\n');
+                                    if (pids.indexOf('' + data) === -1) { /* casting to string because data is apparently an Object */
+                                        logger.error("LockManager: SEVERE: PROCESS WITH PID=" + data + ", OWNER OF LOCK " + lockName +
+                                            ", DOES NOT EXIST. DELETING THE LOCK.");
+                                        fs.unlink(lockFileName, function (err) {
+                                            if (err) {
+                                                logger.error('LockManager: Error while deleting lock ' + lockName + ': ' + err);
+                                            }
+                                        });
+                                    }
+                                });
+                            }
+                        }
+                    });
+
                         setTimeout(self.__obtainExclusiveLock.bind(self, lockName, owner, timeout, firstCallTime, future),
                                    self.settings.lockRetryTimeMillis);
                     }

--- a/lib/lock_manager.js
+++ b/lib/lock_manager.js
@@ -156,7 +156,15 @@ var LockManager = new Class(
                                             logger.error("LockManager: SEVERE: Owner doesn't exist for lock file "+ lockFileName +" , hence deleting the lock file");
                                             fs.unlink(lockFileName, function (err) {
                                                 if (err) {
-                                                    logger.error("LockManager: Error while deleting lock " + lockName + ": " + err);
+                                                    // if file is not there, we don't need to log the error
+                                                    if(err.code === "ENOENT")
+                                                    {
+                                                        logger.info("The file "+lockFileName + "was already deleted by some other process, hence no action is required");
+                                                    }
+                                                    else
+                                                    {
+                                                        logger.error("LockManager: Error while deleting lock " + lockName + ": " + err);
+                                                    }
                                                 }
                                             });
                                         }
@@ -182,7 +190,15 @@ var LockManager = new Class(
                                             ", DOES NOT EXIST. DELETING THE LOCK.");
                                         fs.unlink(lockFileName, function (err) {
                                             if (err) {
-                                                logger.error('LockManager: Error while deleting lock ' + lockName + ': ' + err);
+                                                // if file is not there, we don't need to log the error
+                                                if(err.code === "ENOENT")
+                                                {
+                                                    logger.info("The file "+lockFileName + "was already deleted by some other process, hence no action is required");
+                                                }
+                                                else
+                                                {
+                                                    logger.error('LockManager: Error while deleting lock ' + lockName + ': ' + err);
+                                                }
                                             }
                                         });
                                     }

--- a/lib/lock_manager.js
+++ b/lib/lock_manager.js
@@ -159,7 +159,7 @@ var LockManager = new Class(
                                                     // if file is not there, we don't need to log the error
                                                     if(err.code === "ENOENT")
                                                     {
-                                                        logger.info("The file "+lockFileName + "was already deleted by some other process, hence no action is required");
+                                                        logger.info("LockManager:The file "+lockFileName + "was already deleted by some other process, hence no action is required");
                                                     }
                                                     else
                                                     {
@@ -193,7 +193,7 @@ var LockManager = new Class(
                                                 // if file is not there, we don't need to log the error
                                                 if(err.code === "ENOENT")
                                                 {
-                                                    logger.info("The file "+lockFileName + "was already deleted by some other process, hence no action is required");
+                                                    logger.info("LockManager:The file "+lockFileName + "was already deleted by some other process, hence no action is required");
                                                 }
                                                 else
                                                 {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hurt-locker",
-    "version": "1.4.0",
+    "version": "2.0.1",
     "homepage": "https://github.com/VirtuOz/node-hurt-locker",
     "author": {
         "name": "Kevan Dunsmore",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "hurt-locker",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "homepage": "https://github.com/VirtuOz/node-hurt-locker",
     "author": {
         "name": "Kevan Dunsmore",


### PR DESCRIPTION
**ENINAWEB-2136** : Delete empty lock files if the file is no more in use. 

**Current**: Currently, Kquery server is retrying until timeout and then it's deleting inactive lock file.

**Proposed**:  Before first retry, check if the lock file exist and it's having PID then match with active PID , if there is no match then delete the file and retry. Also, if the file is empty then delete and retry.